### PR TITLE
Clean up `package.json` file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,39 +1,20 @@
 {
   "name": "base64-js",
-  "description": "Base64 encoding/decoding in pure JS",
+  "type": "commonjs",
   "version": "1.5.1",
-  "author": "T. Jameson Little <t.jameson.little@gmail.com>",
-  "typings": "index.d.ts",
-  "bugs": {
-    "url": "https://github.com/feross/base64-js/issues"
-  },
-  "devDependencies": {
-    "babel-minify": "^0.5.1",
-    "benchmark": "^2.1.4",
-    "browserify": "^17.0.0",
-    "standard": "*",
-    "tape": "^5.4.0"
-  },
-  "homepage": "https://github.com/feross/base64-js",
+  "description": "Base64 encoding/decoding in pure JS",
   "keywords": [
     "base64"
   ],
-  "license": "MIT",
-  "main": "index.js",
-  "files": [
-    "base64js.min.js",
-    "index.d.ts",
-    "index.js"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/feross/base64-js.git"
+  "homepage": "https://github.com/feross/base64-js",
+  "bugs": {
+    "url": "https://github.com/feross/base64-js/issues"
   },
-  "scripts": {
-    "build": "browserify -s base64js -r ./ | minify > base64js.min.js",
-    "lint": "standard",
-    "test": "npm run lint && npm run unit",
-    "unit": "tape test/*.js"
+  "license": "MIT",
+  "author": {
+    "name": "T. Jameson Little",
+    "email": "t.jameson.little@gmail.com",
+    "url": "https://jamesonlittle.com"
   },
   "funding": [
     {
@@ -48,5 +29,29 @@
       "type": "consulting",
       "url": "https://feross.org/support"
     }
-  ]
+  ],
+  "files": [
+    "base64js.min.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "main": "index.js",
+  "typings": "index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feross/base64-js.git"
+  },
+  "scripts": {
+    "build": "browserify -s base64js -r ./ | minify > base64js.min.js",
+    "lint": "standard",
+    "test": "npm run lint && npm run unit",
+    "unit": "tape test/*.js"
+  },
+  "devDependencies": {
+    "babel-minify": "^0.5.1",
+    "benchmark": "^2.1.4",
+    "browserify": "^17.0.0",
+    "standard": "*",
+    "tape": "^5.4.0"
+  }
 }


### PR DESCRIPTION
Cleans up the `package.json` by sorting the fields inside (matching the [NPM docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json)) and expanding and adding some fields.